### PR TITLE
Fix typo 'achivement'

### DIFF
--- a/resources/views/mypage.blade.php
+++ b/resources/views/mypage.blade.php
@@ -8,7 +8,7 @@
 
 </div>
 <div class="container">
-  <div class="achivement">
+  <div class="achievement">
     <h2>達成度</h2>
     <div class="achievement_graph row">
       <div class="goods col-md-3">


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'achievement', you typed 'achivement'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
            